### PR TITLE
CS-1039 | Error handling & CloseSession

### DIFF
--- a/Powershell Module/Devolutions.Server/Public/Authentication/Close-DSSession.ps1
+++ b/Powershell Module/Devolutions.Server/Public/Authentication/Close-DSSession.ps1
@@ -9,38 +9,44 @@ function Close-DSSession {
 .LINK
 #>
 	[CmdletBinding()]
-	param(	)
+	param(
+		[switch]$Force
+	)
 
 	BEGIN { 
 		Write-Verbose '[Close-DSSession] begin...'
 		$URI = "$Script:DSBaseURI/api/logout"
+		$GlobalVars = @('DSInstanceName', 'DSInstanceVersion', 'DSKeyExp', 'DSKeyMod', 'DSSafeSessionKey', 'DSSessionKey', 'DSSessionToken', 'WebSession') 
 	}
 
 	PROCESS {
-
-		$params = @{
-			Uri            = $URI
-			Method         = 'GET'
-			LegacyResponse = $true
-		}
-
 		try {
-			$response = Invoke-DS @params
+			if (!$Force) {
+				$params = @{
+					Uri            = $URI
+					Method         = 'GET'
+					LegacyResponse = $true
+				}
+
+				$response = Invoke-DS @params
+			}
 
 			#script scope
 			if (Get-Variable DSBaseUri -Scope Script -ErrorAction SilentlyContinue) { try { Remove-Variable -Name DSBaseURI -Scope Script -Force } catch { } }
 
 			#global scope
-			if (Get-Variable DSInstanceName -Scope Global -ErrorAction SilentlyContinue) { try { Remove-Variable -Name DSInstanceName -Scope Global -Force } catch { } }
-			if (Get-Variable DSInstanceVersion -Scope Global -ErrorAction SilentlyContinue) { try { Remove-Variable -Name DSInstanceVersion -Scope Global -Force } catch { } }
-			if (Get-Variable DSKeyExp -Scope Global -ErrorAction SilentlyContinue) { try { Remove-Variable -Name DSKeyExp -Scope Global -Force } catch { } }
-			if (Get-Variable DSKeyMod -Scope Global -ErrorAction SilentlyContinue) { try { Remove-Variable -Name DSKeyMod -Scope Global -Force } catch { } }
-			if (Get-Variable DSSafeSessionKey -Scope Global -ErrorAction SilentlyContinue) { try { Remove-Variable -Name DSSafeSessionKey -Scope Global -Force } catch { } }
-			if (Get-Variable DSSessionKey -Scope Global -ErrorAction SilentlyContinue) {	try { Remove-Variable -Name DSSessionKey -Scope Global -Force } catch { } }
-			if (Get-Variable DSSessionToken -Scope Global -ErrorAction SilentlyContinue) { try { Remove-Variable -Name DSSessionToken -Scope Global -Force } catch { } }
-			if (Get-Variable WebSession -Scope Global -ErrorAction SilentlyContinue) { try { Remove-Variable -Name WebSession -Scope Global -Force } catch { } }
+			foreach ($Var in $GlobalVars.GetEnumerator()) {
+				try {
+					Remove-Variable -Name $Var -Scope Global -Force -ErrorAction SilentlyContinue
+				}
+				catch {
+					Write-Warning "[Close-DSSession] Error while removing $Var..."
+				}
+			}
 
-			return $response 
+			if (!$Force) {
+				return $response 
+			}
 		}
 		catch {
 			Write-Error $_.Exception.Message

--- a/Powershell Module/Devolutions.Server/Public/Authentication/New-DSSession.ps1
+++ b/Powershell Module/Devolutions.Server/Public/Authentication/New-DSSession.ps1
@@ -27,7 +27,7 @@ Establishes a session with a Devolutions Server
 		#Get-ServerInfo must be called to get encryption keys...
 		if (!(Get-Variable DSSessionKey -Scope Global -ErrorAction SilentlyContinue) -or [string]::IsNullOrWhiteSpace($Global:DSSessionKey)) {
 			$info = Get-DSServerInfo -BaseURI $BaseURI
-			if ($false -eq $info.IsSuccess) {
+			if (!$info.IsSuccess) {
 				throw "Unable to get server information"
 			}
 		}

--- a/Powershell Module/Devolutions.Server/Public/Server/Get-DSServerInfo.ps1
+++ b/Powershell Module/Devolutions.Server/Public/Server/Get-DSServerInfo.ps1
@@ -23,7 +23,7 @@ This endpoint does not require authentication.
 		#We can call the api repeatedly, even after we've established the session.  We must close the existing session only if we change the URI
 		if ((Get-Variable DSBaseURI -Scope Script -ErrorAction SilentlyContinue) -and ($Script:DSBaseURI -ne $BaseURI)) {
 			if ($Global:DSSessionToken) {
-				throw "Session already established, Close it before switching servers."
+				throw 'Session already established, Close it before switching servers.'
 			}
 		}
 
@@ -32,56 +32,65 @@ This endpoint does not require authentication.
 	}
 
 	PROCESS {
-
 		try {
 			$response = Invoke-WebRequest -URI $URI -Method 'GET' -SessionVariable Global:WebSession
-			$resContentJson = $response.Content | ConvertFrom-Json
 
-			If (($null -ne $resContentJson) -and ($null -eq $resContentJson.errorMessage)) {
+			if (Test-Json $response.Content) {
 				$jsonContent = $response.Content | ConvertFrom-JSon
-	
-				Write-Verbose "[Get-DSServerInfo] Got response from ""$($jsonContent.data.servername)"""
+				#If query successful and reached a valid DVLS instance, response's content converted to JSON should only contain 'data' and 'result' fields.
+				$isDVLSInstance = @(Compare-Object $jsonContent.PSObject.Properties.Name @('data', 'result')).Length -eq 0
+
+				if ($isDVLSInstance) {
+					Write-Verbose "[Get-DSServerInfo] Got response from ""$($jsonContent.data.servername)"""
 				
-				If ([System.Management.Automation.ActionPreference]::SilentlyContinue -ne $DebugPreference) {
-					Write-Debug "[Response.Data] $($jsonContent)"
+					If ([System.Management.Automation.ActionPreference]::SilentlyContinue -ne $DebugPreference) {
+						Write-Debug "[Response.Data] $($jsonContent)"
+					}
+				
+					$publickey_mod = $jsonContent.data.publicKey.modulus
+					$publickey_exp = $jsonContent.data.publicKey.exponent
+					$session_Key = New-CryptographicKey
+					$safeSessionKey = Encrypt-RSA -publickey_mod $publickey_mod -publickey_exp $publickey_exp -session_Key $session_Key
+
+					[System.Version]$instanceVersion = $jsonContent.data.version
+
+					Set-Variable -Name DSBaseURI -Value $BaseURI -Scope Script
+
+					Set-Variable -Name DSKeyExp -Value $publickey_exp -Scope Global
+					Set-Variable -Name DSKeyMod -Value $publickey_mod -Scope Global
+					Set-Variable -Name DSSessionKey -Value $session_Key -Scope Global
+					Set-Variable -Name DSSafeSessionKey -Value $safeSessionKey -Scope Global
+					Set-Variable -Name DSInstanceVersion -Value $instanceVersion -Scope Global
+					Set-Variable -Name DSInstanceName -Value $jsonContent.data.serverName -Scope Global
+
+					$res = [ServerResponse]::new(($response.StatusCode -eq 200), $response, $jsonContent, $null, '', $response.StatusCode)
+					return $res
 				}
-				
-				$publickey_mod = $jsonContent.data.publicKey.modulus
-				$publickey_exp = $jsonContent.data.publicKey.exponent
-				$session_Key = New-CryptographicKey
-				$safeSessionKey = Encrypt-RSA -publickey_mod $publickey_mod -publickey_exp $publickey_exp -session_Key $session_Key
-
-				[System.Version]$instanceVersion = $jsonContent.data.version
-
-				Set-Variable -Name DSBaseURI -Value $BaseURI -Scope Script
-
-				Set-Variable -Name DSKeyExp -Value $publickey_exp -Scope Global
-				Set-Variable -Name DSKeyMod -Value $publickey_mod -Scope Global
-				Set-Variable -Name DSSessionKey -Value $session_Key -Scope Global
-				Set-Variable -Name DSSafeSessionKey -Value $safeSessionKey -Scope Global
-				Set-Variable -Name DSInstanceVersion -Value $instanceVersion -Scope Global
-				Set-Variable -Name DSInstanceName -Value $jsonContent.data.serverName -Scope Global
-
-				return [ServerResponse]::new(($response.StatusCode -eq 200), $response, $jsonContent, $null, "", $response.StatusCode)
+				else {
+					throw 'There was a problem reaching your DVLS instance. Please check your DVLS instance URL and try again.'
+				}
 			}
 			else {
-				throw [Exception]::new("Could not connect to database. Make sure your database is running and you have the right credentials in DVLS Console.")
+				throw 'There was a problem reaching your DVLS instance. Please check your DVLS instance URL and try again.'
 			}
 		}
 		catch {
-			$exc = $_.Exception
-			If ([System.Management.Automation.ActionPreference]::SilentlyContinue -ne $DebugPreference) {
-				Write-Debug "[Exception] $exc"
-			} 
+			#$exc = $_.Exception
+			#If ([System.Management.Automation.ActionPreference]::SilentlyContinue -ne $DebugPreference) {
+			#	Write-Debug "[Exception] $exc"
+			#} 
+
+			Write-Error 'There was a problem reaching your DVLS instance. Please check your DVLS instance URL and try again.'
+			throw $_.Exception.Message
 		}
 	}
 
 	END {
-		If ($?) {
-			Write-Verbose '[Get-DSServerInfo] Completed Successfully.'
+		If ($res.isSuccess) {
+			Write-Verbose '[Get-DSServerInfo] Completed Successfully!'
 		}
 		else {
-			Write-Verbose '[Get-DSServerInfo] ended with errors...'
+			Write-Verbose '[Get-DSServerInfo] Ended with errors...'
 		}
 	}
 }


### PR DESCRIPTION
New-DSSession now throws an error if there's an error during login instead of returning server response. No point in continuing execution without proper token.

Get-DSServerInfo throws error if anything happens (Host not found, host not a DVLS instance...)

Close-DSSession now has a Force parameter to bypass backend logout and still clear global variables