### PR TITLE
PAM Checkout/Checkin

### DIFF
--- a/Powershell Module/Devolutions.Server/Devolutions.Server.psd1
+++ b/Powershell Module/Devolutions.Server/Devolutions.Server.psd1
@@ -51,7 +51,7 @@
     # RequiredAssemblies   = @()
     
     # Script files (.ps1) that are run in the caller's environment prior to importing this module.
-    ScriptsToProcess     = @('.\Private\Types\Field.ps1', '.\Private\Types\ServerResponse.ps1')
+    ScriptsToProcess     = @('.\Private\Types\Field.ps1', '.\Private\Types\ServerResponse.ps1', '.\Private\Types\PamCheckout.ps1')
     
     # Type files (.ps1xml) to be loaded when importing this module
     # TypesToProcess = @()
@@ -76,6 +76,8 @@
         'New-DSEntryBase', 'Update-DSEntryBase', 'New-DSRDPEntry', 'Update-DSRDPEntry', 'New-DSSSHShellEntry', 'Update-DSSSHShellEntry',
 
         'Get-DSPasswordsReport'
+
+        'Invoke-DSPamCheckout', 'Invoke-DSPamCheckin', 'Get-DSPamCheckout', 'Get-DSPamCredential'
     )
     
     # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.

--- a/Powershell Module/Devolutions.Server/Devolutions.Server.psd1
+++ b/Powershell Module/Devolutions.Server/Devolutions.Server.psd1
@@ -77,7 +77,7 @@
 
         'Get-DSPasswordsReport'
 
-        'Invoke-DSPamCheckout', 'Invoke-DSPamCheckin', 'Get-DSPamCheckout', 'Get-DSPamCredential'
+        'Invoke-DSPamCheckout', 'Invoke-DSPamCheckin', 'Get-DSPamCheckout', 'Get-DSPamCredential', 'Invoke-DSPamCheckoutPending', 'Get-DSPamPassword'
     )
     
     # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.

--- a/Powershell Module/Devolutions.Server/Private/Types/PamCheckout.ps1
+++ b/Powershell Module/Devolutions.Server/Private/Types/PamCheckout.ps1
@@ -1,0 +1,53 @@
+class PamCheckout {
+    [Nullable[guid]]$ID
+    [Nullable[guid]]$UserID
+    [string]$Username
+    [Nullable[guid]]$CredentialID
+    [string]$CredentialName
+    [Nullable[guid]]$ApproverID
+    [string]$ApproverName
+    [string]$Reason
+    [string]$ApproverMessage
+    [string]$Status
+    [Nullable[int]]$Duration
+    [Nullable[datetime]]$RequestDateTime
+    [Nullable[datetime]]$CheckoutDateTime
+    [Nullable[datetime]]$CheckInDateTime
+    [PSCustomObject]$ResolvedPermissions
+
+    PamCheckout([PSCustomObject]$PamCheckout) {
+        $this.ID = $PamCheckout.ID
+        $this.UserID = $PamCheckout.UserID
+        $this.Username = $PamCheckout.Username
+        $this.CredentialID = $PamCheckout.CredentialID
+        $this.CredentialName = $PamCheckout.CredentialName
+        $this.ApproverID = $PamCheckout.ApproverID
+        $this.ApproverName = $PamCheckout.ApproverName
+        $this.Reason = $PamCheckout.Reason
+        $this.ApproverMessage = $PamCheckout.ApproverMessage
+        $this.Status = $PamCheckout.Status
+        $this.Duration = $PamCheckout.Duration
+        $this.RequestDateTime = $PamCheckout.RequestDateTime
+        $this.CheckoutDateTime = $PamCheckout.CheckoutDateTime
+        $this.CheckInDateTime = $PamCheckout.CheckInDateTime
+        $this.ResolvedPermissions = $PamCheckout.ResolvedPermissions
+    }
+
+    PamCheckout() {
+        $this.ID = [guid]::NewGuid()
+        $this.UserID = [guid]::NewGuid()
+        $this.Username = $null
+        $this.CredentialID = [guid]::NewGuid()
+        $this.CredentialName = $null
+        $this.ApproverID = [guid]::NewGuid()
+        $this.ApproverName = $null
+        $this.Reason = $null
+        $this.ApproverMessage = $null
+        $this.Status = $null
+        $this.Duration = $null
+        $this.RequestDateTime = $null
+        $this.CheckoutDateTime = $null
+        $this.CheckInDateTime = $null
+        $this.ResolvedPermissions = $null
+    }
+}

--- a/Powershell Module/Devolutions.Server/Private/Types/enums/CheckoutStatus.generated.ps1
+++ b/Powershell Module/Devolutions.Server/Private/Types/enums/CheckoutStatus.generated.ps1
@@ -1,0 +1,13 @@
+enum CheckoutStatus 
+{
+    Invalid = 0
+    Pending = 1
+    Granted = 2
+    Denied = 3
+    Active = 4
+    Ended = 5
+    Expired = 6
+    Aborted = 7
+    RequestCanceled = 8
+    Initial = 9
+}

--- a/Powershell Module/Devolutions.Server/Public/Pam/Checkout/Get-DSPamCheckout.ps1
+++ b/Powershell Module/Devolutions.Server/Public/Pam/Checkout/Get-DSPamCheckout.ps1
@@ -1,0 +1,32 @@
+function Get-DSPamCheckout {
+    [CmdletBinding()]
+    PARAM (
+        [guid]$PamCredentialID
+    )
+    
+    BEGIN {
+        Write-Verbose '[Get-DSPamCheckout] Beginning...'
+
+        if ([string]::IsNullOrWhiteSpace($Global:DSSessionToken)) {
+            throw 'Session does not seem authenticated, call New-DSSession.'
+        }
+    }
+    
+    PROCESS {
+        $RequestParams = @{
+            URI    = "$Script:DSBaseURI/api/pam/checkouts" 
+            Method = 'POST' 
+            Body   = (ConvertTo-Json @{ credentialID = $PamCredentialID; duration = 240 })
+        }
+
+        try {
+            $res = Invoke-DS @RequestParams
+            return $res
+        }
+        catch { throw $_.ErrorDetails }
+    }
+    
+    END {
+        $res.isSuccess ? (Write-Verbose '[Get-DSPamCheckout] Completed successfully!') : (Write-Verbose '[Get-DSPamCheckout] Ended with errors...')
+    }
+}

--- a/Powershell Module/Devolutions.Server/Public/Pam/Checkout/Get-DSPamCheckout.ps1
+++ b/Powershell Module/Devolutions.Server/Public/Pam/Checkout/Get-DSPamCheckout.ps1
@@ -14,11 +14,10 @@ function Get-DSPamCheckout {
     
     PROCESS {
         $RequestParams = @{
-            URI    = "$Script:DSBaseURI/api/pam/checkouts" 
-            Method = 'POST' 
-            Body   = (ConvertTo-Json @{ credentialID = $PamCredentialID; duration = 240 })
+            URI    = "$Script:DSBaseURI/api/pam/checkouts/$PamCredentialID"
+            Method = 'GET' 
         }
-
+        
         try {
             $res = Invoke-DS @RequestParams
             return $res

--- a/Powershell Module/Devolutions.Server/Public/Pam/Checkout/Get-DSPamCheckout.ps1
+++ b/Powershell Module/Devolutions.Server/Public/Pam/Checkout/Get-DSPamCheckout.ps1
@@ -1,4 +1,10 @@
 function Get-DSPamCheckout {
+    <#
+        .SYNOPSIS
+        Returns the current checkout state of the provided PAM credential.
+        .EXAMPLE
+        Please check the sample script provided with the module.
+    #>
     [CmdletBinding()]
     PARAM (
         [guid]$PamCredentialID

--- a/Powershell Module/Devolutions.Server/Public/Pam/Checkout/Invoke-DSPamCheckin.ps1
+++ b/Powershell Module/Devolutions.Server/Public/Pam/Checkout/Invoke-DSPamCheckin.ps1
@@ -1,4 +1,12 @@
 function Invoke-DSPamCheckin {
+    <#
+        .SYNOPSIS
+        Check in a currently checked out PAM credential.
+        .DESCRIPTION
+        To retreive the checkout, as a [PamCheckout] object, pleasee use Get-DSPamCheckout CMDlet.
+        .EXAMPLE
+        Please check the sample script provided with the module.
+    #>
     [CmdletBinding()]
     PARAM (
         [Parameter(Mandatory)]

--- a/Powershell Module/Devolutions.Server/Public/Pam/Checkout/Invoke-DSPamCheckin.ps1
+++ b/Powershell Module/Devolutions.Server/Public/Pam/Checkout/Invoke-DSPamCheckin.ps1
@@ -17,7 +17,7 @@ function Invoke-DSPamCheckin {
         $PamCheckout.status = [CheckoutStatus]::Ended
 
         $RequestParams = @{
-            URI    = "$Script:DSBaseURI/api/pam/checkouts/${$PamCheckout.ID}"
+            URI    = "$Script:DSBaseURI/api/pam/checkouts/$($PamCheckout.ID)"
             Method = 'PUT'
             Body   = (ConvertTo-Json $PamCheckout)
         }

--- a/Powershell Module/Devolutions.Server/Public/Pam/Checkout/Invoke-DSPamCheckin.ps1
+++ b/Powershell Module/Devolutions.Server/Public/Pam/Checkout/Invoke-DSPamCheckin.ps1
@@ -1,0 +1,35 @@
+function Invoke-DSPamCheckin {
+    [CmdletBinding()]
+    PARAM (
+        [Parameter(Mandatory)]
+        [PamCheckout]$PamCheckout
+    )
+    
+    BEGIN {
+        Write-Verbose '[Invoke-DSPamCheckin] Beginning...'
+
+        if ([string]::IsNullOrWhiteSpace($Global:DSSessionToken)) {
+            throw 'Session does not seem authenticated, call New-DSSession.'
+        }
+    }
+    
+    PROCESS {
+        $PamCheckout.status = [CheckoutStatus]::Ended
+
+        $RequestParams = @{
+            URI    = "$Script:DSBaseURI/api/pam/checkouts/${$PamCheckout.ID}"
+            Method = 'PUT'
+            Body   = (ConvertTo-Json $PamCheckout)
+        }
+
+        try {
+            $res = Invoke-DS @RequestParams
+            return $res
+        }
+        catch { throw $_.ErrorDetails }
+    }
+    
+    END {
+        $res.isSuccess ? (Write-Verbose '[Invoke-DSPamCheckin] Completed successfully!') : (Write-Verbose '[Invoke-DSPamCheckin] Ended with errors...')
+    }
+}

--- a/Powershell Module/Devolutions.Server/Public/Pam/Checkout/Invoke-DSPamCheckout.ps1
+++ b/Powershell Module/Devolutions.Server/Public/Pam/Checkout/Invoke-DSPamCheckout.ps1
@@ -17,7 +17,13 @@ function Invoke-DSPamCheckout {
         $PamCredential = ($res = Get-DSPamCredential $PamCredentialID).isSuccess ? ($res.Body) : $(throw 'Failed while fetching credentials. Please make sure the ID you provided is a valid PAM account ID and try again.')
 
         #2. Checkout
-        [PamCheckout]$CredentialCheckout = ($res = Get-DSPamCheckout $PamCredentialID).isSuccess ? ($res.Body) : ($res.ErrorMessage ? $(throw $res.ErrorMessage) : $(throw 'Failed while trying to checkout the account. See logs for information.'))
+        $RequestParams = @{
+            URI    = "$Script:DSBaseURI/api/pam/checkouts"
+            Method = 'POST'
+            Body   = (ConvertTo-Json @{credentialID = $PamCredentialID; duration = $PamCredential.duration})
+        }
+
+        [PamCheckout]$CredentialCheckout = ($res = Invoke-DS @RequestParams).isSuccess ? ($res.Body) : ($res.ErrorMessage ? $(throw $res.ErrorMessage) : $(throw 'Failed while trying to checkout the account. See logs for information.'))
 
         #3. Get Password
         $EncryptedPassword = ($res = Get-DSPamPassword $PamCredentialID).isSuccess ? ($res.Body) : ($res.ErrorMessage ? $(throw $res.ErrorMessage): $(throw 'Failed while fetching password. See logs for information.'))

--- a/Powershell Module/Devolutions.Server/Public/Pam/Checkout/Invoke-DSPamCheckout.ps1
+++ b/Powershell Module/Devolutions.Server/Public/Pam/Checkout/Invoke-DSPamCheckout.ps1
@@ -1,7 +1,9 @@
 function Invoke-DSPamCheckout {
     [CmdletBinding()]
     PARAM (
-        [guid]$PamCredentialID = $(throw 'You must provide a valid ID.')
+        [guid]$PamCredentialID = $(throw 'You must provide a valid ID.'),
+        [string]$Reason,
+        [guid]$ApproverID
     )
     
     BEGIN {
@@ -13,26 +15,50 @@ function Invoke-DSPamCheckout {
     }
     
     PROCESS {
-        #1. Fetch PAM cred (api/pam/credentials/$id)
+        #1. Fetch PAM cred (api/pam/credentials/$id) 
         $PamCredential = ($res = Get-DSPamCredential $PamCredentialID).isSuccess ? ($res.Body) : $(throw 'Failed while fetching credentials. Please make sure the ID you provided is a valid PAM account ID and try again.')
+    
+        #1.1 Check for approver
+        if (($PamCredential.checkoutApprovalMode -eq 2) -and !$ApproverID) {
+            Write-Error 'This entry requires an approver to check out. Please provide an approver ID and try again.'
+        }
+
+        #1.2 Check for reason mode
+        if (($PamCredential.checkoutReasonMode -eq 2) -and !$Reason) {
+            Write-Error 'This entry requires a reason to check out. Please provide a reason and try again.'
+        }
 
         #2. Checkout
         $RequestParams = @{
             URI    = "$Script:DSBaseURI/api/pam/checkouts"
             Method = 'POST'
-            Body   = (ConvertTo-Json @{credentialID = $PamCredentialID; duration = $PamCredential.duration})
+            Body   = @{credentialID = $PamCredentialID; duration = 240 }
         }
+
+        if ($PamCredential.checkoutApprovalMode -eq 2) {
+            $RequestParams.Body += @{approverID = $ApproverID }
+        }
+
+        if ($PamCredential.checkoutReasonMode -in @(2, 3)) {
+            $RequestParams.Body += @{reason = $Reason }
+        }
+
+        $RequestParams.Body = ConvertTo-Json $RequestParams.Body
 
         [PamCheckout]$CredentialCheckout = ($res = Invoke-DS @RequestParams).isSuccess ? ($res.Body) : ($res.ErrorMessage ? $(throw $res.ErrorMessage) : $(throw 'Failed while trying to checkout the account. See logs for information.'))
 
-        #3. Get Password
-        $EncryptedPassword = ($res = Get-DSPamPassword $PamCredentialID).isSuccess ? ($res.Body) : ($res.ErrorMessage ? $(throw $res.ErrorMessage): $(throw 'Failed while fetching password. See logs for information.'))
+        if ($CredentialCheckout.Status -ne 1) {
+            #3. Get Password
+            $EncryptedPassword = ($res = Get-DSPamPassword $PamCredentialID).isSuccess ? ($res.Body) : ($res.ErrorMessage ? $(throw $res.ErrorMessage): $(throw 'Failed while fetching password. See logs for information.'))
 
-        #4. Decrypt password
-        $DecryptedPassword = Decrypt-String $Global:DSSessionKey $EncryptedPassword
+            #4. Decrypt password
+            $DecryptedPassword = Decrypt-String $Global:DSSessionKey $EncryptedPassword
 
-        #5. Return checkout info and decrypted password
-        return @{CheckoutInfo = $CredentialCheckout; Password = $DecryptedPassword }
+            #5. Return checkout info and decrypted password
+            return @{CheckoutInfo = $CredentialCheckout; Password = $DecryptedPassword }
+        }
+        
+        return $CredentialCheckout
     }
     
     END {

--- a/Powershell Module/Devolutions.Server/Public/Pam/Checkout/Invoke-DSPamCheckout.ps1
+++ b/Powershell Module/Devolutions.Server/Public/Pam/Checkout/Invoke-DSPamCheckout.ps1
@@ -5,7 +5,11 @@ function Invoke-DSPamCheckout {
     )
     
     BEGIN {
-        
+        Write-Verbose '[Invoke-DSPamCheckout] Beginning...'
+
+        if ([string]::IsNullOrWhiteSpace($Global:DSSessionToken)) {
+            throw 'Session does not seem authenticated, call New-DSSession.'
+        }
     }
     
     PROCESS {

--- a/Powershell Module/Devolutions.Server/Public/Pam/Checkout/Invoke-DSPamCheckout.ps1
+++ b/Powershell Module/Devolutions.Server/Public/Pam/Checkout/Invoke-DSPamCheckout.ps1
@@ -1,0 +1,31 @@
+function Invoke-DSPamCheckout {
+    [CmdletBinding()]
+    PARAM (
+        [guid]$PamCredentialID = $(throw 'You must provide a valid ID.')
+    )
+    
+    BEGIN {
+        
+    }
+    
+    PROCESS {
+        #1. Fetch PAM cred (api/pam/credentials/$id)
+        $PamCredential = ($res = Get-DSPamCredential $PamCredentialID).isSuccess ? ($res.Body) : $(throw 'Failed while fetching credentials. Please make sure the ID you provided is a valid PAM account ID and try again.')
+
+        #2. Checkout
+        [PamCheckout]$CredentialCheckout = ($res = Get-DSPamCheckout $PamCredentialID).isSuccess ? ($res.Body) : ($res.ErrorMessage ? $(throw $res.ErrorMessage) : $(throw 'Failed while trying to checkout the account. See logs for information.'))
+
+        #3. Get Password
+        $EncryptedPassword = ($res = Get-DSPamPassword $PamCredentialID).isSuccess ? ($res.Body) : ($res.ErrorMessage ? $(throw $res.ErrorMessage): $(throw 'Failed while fetching password. See logs for information.'))
+
+        #4. Decrypt password
+        $DecryptedPassword = Decrypt-String $Global:DSSessionKey $EncryptedPassword
+
+        #5. Return checkout info and decrypted password
+        return @{CheckoutInfo = $CredentialCheckout; Password = $DecryptedPassword }
+    }
+    
+    END {
+        $res.isSuccess ? (Write-Verbose '[Invoke-DSPamCheckout] Completed successfully!') : (Write-Verbose '[Invoke-DSPamCheckout] Ended with errors...')
+    }
+}

--- a/Powershell Module/Devolutions.Server/Public/Pam/Checkout/Invoke-DSPamCheckoutPending.ps1
+++ b/Powershell Module/Devolutions.Server/Public/Pam/Checkout/Invoke-DSPamCheckoutPending.ps1
@@ -1,4 +1,12 @@
 function Invoke-DSPamCheckoutPending {
+    <#
+        .SYNOPSIS
+        Approve or deny a pending checkout request.
+        .DESCRIPTION
+        Change the state of a pending checkout request depending on the -Accept flag parameter.
+        .EXAMPLE
+        Please check the sample script provided with the module.
+    #>
     [CmdletBinding()]
     PARAM (
         [PamCheckout]$CredentialCheckout,

--- a/Powershell Module/Devolutions.Server/Public/Pam/Checkout/Invoke-DSPamCheckoutPending.ps1
+++ b/Powershell Module/Devolutions.Server/Public/Pam/Checkout/Invoke-DSPamCheckoutPending.ps1
@@ -1,0 +1,34 @@
+function Invoke-DSPamCheckoutPending {
+    [CmdletBinding()]
+    PARAM (
+        [PamCheckout]$CredentialCheckout,
+        [switch]$Accept,
+        [string]$ApproverMessage = $null
+    )
+    
+    BEGIN {
+        Write-Verbose '[Invoke-DSPamCheckout] Beginning...'
+
+        if ([string]::IsNullOrWhiteSpace($Global:DSSessionToken)) {
+            throw 'Session does not seem authenticated, call New-DSSession.'
+        }
+    }
+    
+    PROCESS {
+        $CredentialCheckout.Status = $Accept ? 4 : 3
+        $CredentialCheckout.ApproverMessage = $ApproverMessage
+
+        $RequestParams = @{
+            URI    = "$Script:DSBaseURI/api/pam/checkouts/$($CredentialCheckout.ID)"
+            Method = 'PUT'
+            Body   = ConvertTo-Json $CredentialCheckout
+        }
+
+        $res = Invoke-DS @RequestParams
+        return $res
+    }
+    
+    END {
+        $res.isSuccess ? (Write-Verbose '[Invoke-DSPamCheckout] Completed successfully!') : (Write-Verbose '[Invoke-DSPamCheckout] Ended with errors...')
+    }
+}

--- a/Powershell Module/Devolutions.Server/Public/Pam/Credentials/Get-DSPamCredential.ps1
+++ b/Powershell Module/Devolutions.Server/Public/Pam/Credentials/Get-DSPamCredential.ps1
@@ -1,0 +1,31 @@
+function Get-DSPamCredential {
+    [CmdletBinding()]
+    PARAM (
+        [guid]$PamCredentialID
+    )
+    
+    BEGIN {
+        Write-Verbose '[Get-DSPamCredential] Beginning...'
+
+        if ([string]::IsNullOrWhiteSpace($Global:DSSessionToken)) {
+            throw 'Session does not seem authenticated, call New-DSSession.'
+        }
+    }
+    
+    PROCESS {
+        $RequestParams = @{
+            URI    = "$Script:DSBaseURI/api/pam/credentials/$PamCredentialID"
+            Method = 'GET'
+        }
+
+        try { 
+            $res = Invoke-DS @RequestParams
+            return $res
+        }
+        catch { throw $_.ErrorDetails }
+    }
+    
+    END {
+        $res.isSuccess ? (Write-Verbose '[Get-DSPamCredential] Completed successfully!') : (Write-Verbose '[Get-DSPamCredential] Ended with errors...')
+    }
+}

--- a/Powershell Module/Devolutions.Server/Public/Pam/Passwords/Get-DSPamPassword.ps1
+++ b/Powershell Module/Devolutions.Server/Public/Pam/Passwords/Get-DSPamPassword.ps1
@@ -1,0 +1,31 @@
+function Get-DSPamPassword {
+    [CmdletBinding()]
+    PARAM (
+        [guid]$PamCredentialID
+    )
+    
+    BEGIN {
+        Write-Verbose '[Get-DSPamPassword] Beginning...'
+
+        if ([string]::IsNullOrWhiteSpace($Global:DSSessionToken)) {
+            throw 'Session does not seem authenticated, call New-DSSession.'
+        }
+    }
+    
+    PROCESS {
+        $RequestParams = @{
+            URI    = "$Script:DSBaseURI/api/pam/passwords/$PamCredentialID"
+            Method = 'GET'
+        }
+
+        try {
+            $res = Invoke-DS @RequestParams
+            return $res
+        }
+        catch { throw $_.ErrorDetails }
+    }
+    
+    END {
+        $res.isSuccess ? (Write-Verbose '[Get-DSPamPassword] Completed successfully!') : (Write-Verbose '[Get-DSPamPassword] Ended with errors...')
+    }
+}

--- a/Powershell Module/Devolutions.Server/Public/Pam/Passwords/Get-DSPamPassword.ps1
+++ b/Powershell Module/Devolutions.Server/Public/Pam/Passwords/Get-DSPamPassword.ps1
@@ -20,6 +20,7 @@ function Get-DSPamPassword {
 
         try {
             $res = Invoke-DS @RequestParams
+            $res.Body = [pscustomobject]@{encrypted = $res.Body; decrypted = (Decrypt-String $Global:DSSessionKey $res.Body) }
             return $res
         }
         catch { throw $_.ErrorDetails }

--- a/Powershell Module/Devolutions.Server/Public/Pam/Passwords/Get-DSPamPassword.ps1
+++ b/Powershell Module/Devolutions.Server/Public/Pam/Passwords/Get-DSPamPassword.ps1
@@ -1,4 +1,14 @@
 function Get-DSPamPassword {
+    <#
+        .SYNOPSIS
+        Returns the PAM credential password.
+        .DESCRIPTION
+        Retrurns the PAM credential password if it is currently checked out and user has rights. By default,
+        password stays encrypted. The 'Decrypted' flag need to be present in order to see the password
+        in clear text.
+        .EXAMPLE
+        Please check the sample script provided with the module.
+    #>
     [CmdletBinding()]
     PARAM (
         [guid]$PamCredentialID,

--- a/Powershell Module/Devolutions.Server/Public/Pam/Passwords/Get-DSPamPassword.ps1
+++ b/Powershell Module/Devolutions.Server/Public/Pam/Passwords/Get-DSPamPassword.ps1
@@ -1,7 +1,8 @@
 function Get-DSPamPassword {
     [CmdletBinding()]
     PARAM (
-        [guid]$PamCredentialID
+        [guid]$PamCredentialID,
+        [switch]$Decrypted
     )
     
     BEGIN {
@@ -20,7 +21,7 @@ function Get-DSPamPassword {
 
         try {
             $res = Invoke-DS @RequestParams
-            $res.Body = [pscustomobject]@{encrypted = $res.Body; decrypted = (Decrypt-String $Global:DSSessionKey $res.Body) }
+            if ($Decrypted) { $res.Body = (Decrypt-String $Global:DSSessionKey $res.Body) }
             return $res
         }
         catch { throw $_.ErrorDetails }

--- a/Powershell Module/Samples/PAMExamples.ps1
+++ b/Powershell Module/Samples/PAMExamples.ps1
@@ -1,0 +1,61 @@
+################################################################################
+#
+# This script is used to demonstrate how to use the PAM CMDlets present
+# in this module. Before hand, you need to make sure you have the IDs of the
+# PAM credential you want to manipulate and the user ID for approval, if
+# required.
+#
+# The following CMDlets are used to manipulate a PAM credential:
+# Get-DSPamCredential
+#   Returns the PAM credential
+#
+# Invoke-DSPamCheckout
+#   Generate a checkout request and auto-approve if possible/approverID is set
+#   the same as the asking user ID.
+#
+# Invoke-DSPamCheckoutPending
+#   If used with the -Accept flag parameter, it checks out the credential
+#   and return the credential as an object and the decrypted password.
+#
+# Invoke-DSPamCheckin
+#   Checks in a currently active credential and returns the state of said
+#   credential
+################################################################################
+
+<# Setup #>
+$ModulePath = Resolve-Path -Path '..\Powershell Module\Devolutions.Server'
+Import-Module -Name $ModulePath -Force
+
+[string]$Username = $env:DS_USER
+[string]$Password = $env:DS_PASSWORD
+[string]$DVLSUrl = $env:DS_URL
+
+[securestring]$SecPassword = ConvertTo-SecureString $Password -AsPlainText -Force
+[pscredential]$Creds = New-Object System.Management.Automation.PSCredential ($Username, $SecPassword)
+
+$Response = New-DSSession -Credential $Creds -BaseURI $DVLSUrl 
+
+if ($null -eq $Response.Body.data.tokenId) {
+    Write-Error "Unable to authenticate to DVLS instance: $DVLSUrl"
+}
+
+<# -- Auto checkout -- #>
+$Response = Invoke-DSPamCheckout -PamCredentialID '92e1d27f-6e7b-4c62-86da-a04fc22603c2'  -Verbose
+$BobPassword = $Response.Body.Password
+$BobCheckoutInfo = $Response.Body.CheckoutInfo
+
+# -- Self checkout -- #
+$Response = Invoke-DSPamCheckout -PamCredentialID '2735a06c-baa0-4ff9-911c-aa1fcc03ea1e' -Reason 'Because' -ApproverID '49a60972-b1ff-4be9-ac73-47c6d4a4125d'
+$MauricePassword = $Response.Body.Password
+$MauriceCheckoutInfo = $Response.Body.CheckoutInfo
+
+# -- Approver checkout -- #
+$Response = Invoke-DSPamCheckout -PamCredentialID '08a521fe-14f7-4ae5-b2b9-d9f6164c15e8' -ApproverID '2364ec1f-a739-450b-afe8-d85b5a3db50e' -Reason 'Because'
+$CheckoutResponse = Invoke-DSPamCheckoutPending -CredentialCheckout $Response.Body -Accept -ApproverMessage 'Approved'
+$KellyPassword = Get-DSPamPassword -PamCredentialID $CheckoutResponse.Body.credentialID -Decrypted
+$KellyCheckoutInfo = $CheckoutResponse.Body
+
+<# Check in #>
+$BobCheckinResponse = Invoke-DSPamCheckin $BobCheckoutInfo
+$MauriceCheckinResponse = Invoke-DSPamCheckin $MauriceCheckoutInfo
+$KellyCheckinResponse = Invoke-DSPamCheckin $KellyCheckoutInfo


### PR DESCRIPTION
- Added PamCheckout type
- Added CheckoutStatus enum
- Added Invoke-DSPamCheckout
    - Returns a checkout object (represent the checkout request)
    - Automatically approved and returns hashtable {checkoutinfo,  password} if: 
        - No approver
        - ApproverID is same as asking user ID
- Added Invoke-DSPamCheckoutPending
    - Accept or decline using -Accept flag parameter and returns PAM checkout object
- Added Invoke-DSPamCheckin
    - Returns a PamCheckout object if checkin was successful