### PR TITLE
Added classes to ScriptsToProcess in manifest

### DIFF
--- a/Powershell Module/Devolutions.Server/Devolutions.Server.psd1
+++ b/Powershell Module/Devolutions.Server/Devolutions.Server.psd1
@@ -51,7 +51,9 @@
     # RequiredAssemblies   = @()
     
     # Script files (.ps1) that are run in the caller's environment prior to importing this module.
-    ScriptsToProcess     = @('.\Private\Types\Field.ps1', '.\Private\Types\ServerResponse.ps1', '.\Private\Types\PamCheckout.ps1')
+    ScriptsToProcess     = @('.\Private\Types\Field.ps1', '.\Private\Types\ServerResponse.ps1', '.\Private\Types\PamCheckout.ps1', 
+        '.\Classes\BaseConnection.generated.ps1', '.\Classes\ConnectionPermission.generated.ps1', '.\Classes\DataSourcePermission.generated.ps1', '.\Classes\SecurityConnection.generated.ps1',
+        '.\Classes\BrowserExtensionMetaData.generated.ps1', '.\Classes\ConnectionMetaDataEntity.generated.ps1', '.\Classes\ConnectionInfoEntity.generated.ps1')
     
     # Type files (.ps1xml) to be loaded when importing this module
     # TypesToProcess = @()


### PR DESCRIPTION
Maybe this is not the Powershell way... Is it normal to dotsource when needed or loading classes this way is fine? I couldn't see this being manageable for long on a bigger project.