### PR TITLE
Add missing description in  New-DSRDPEntry

### DIFF
--- a/Powershell Module/Devolutions.Server/Public/Entries/New-DSRDPEntry.ps1
+++ b/Powershell Module/Devolutions.Server/Public/Entries/New-DSRDPEntry.ps1
@@ -197,6 +197,7 @@ function New-DSRDPEntry {
                 connectionType        = 1
                 group                 = $Group
                 name                  = $Name
+                description           = $Description
                 displayMode           = $DisplayMode
                 DisplayMonitor        = $DisplayMonitor
                 displayVirtualDesktop = $DisplayVirtualDesktop


### PR DESCRIPTION
Description is a parameter but it is never actually set during creation